### PR TITLE
 Added missing dependencies

### DIFF
--- a/inkscape/inkscape.rb
+++ b/inkscape/inkscape.rb
@@ -48,7 +48,6 @@ class Inkscape < Formula
     system "../po/generate_POTFILES.sh"
     system "ninja", "inkscape_pot"
     system "ninja"
-    system "mkdir", "/usr/local/share/inkscape"
     system "ninja", "install"
   end
 

--- a/inkscape/inkscape.rb
+++ b/inkscape/inkscape.rb
@@ -2,7 +2,7 @@ class Inkscape < Formula
   desc "Open-source vector graphics editor"
   homepage "https://inkscape.org/"
   url "https://gitlab.com/inkscape/inkscape/-/archive/master/inkscape-master.tar.bz2"
-  sha256 "cd55cc6e789501e21260a2c323a162be15f2c6904c394cea191455cc42b7a8fc"
+  sha256 "56306accbcd3c626c0a4a3c12929722355751bd009584fa2f4397bc502413443"
   head "https://gitlab.com/inkscape/inkscape.git"
 
   # tools
@@ -30,6 +30,8 @@ class Inkscape < Formula
   depends_on "libsoup" => :build
   depends_on "libwpg" => :build
   depends_on "graphicsmagick" => :build
+  depends_on "double-conversion" => :build
+  depends_on "gettext" => :build
   # optional deps
   depends_on "jemalloc" => :optional
   depends_on "libvisio" => :optional
@@ -46,6 +48,7 @@ class Inkscape < Formula
     system "../po/generate_POTFILES.sh"
     system "ninja", "inkscape_pot"
     system "ninja"
+    system "mkdir", "/usr/local/share/inkscape"
     system "ninja", "install"
   end
 


### PR DESCRIPTION
* dependencies for `double-conversion`and `gettext`have been added
* sha256 has been changed

after that, the compilation works successfully, however, the installation fails because `/usr/local/share/inkscape` was not created. The problem seems to be related to the installation directory and the fact that is protected by MacOS' SIP. I tried changing `LIBPREFIX`to `ENV.prepend_path "LIBPREFIX", prefix` (resulting in the variable set to `/usr/local/Cellar/inkscape/master`, which I think is correct), but I think there is code that needs to be fixed in Inkscapes build files. 

So in essence: Build now works, but the installation fails.